### PR TITLE
XIVY-6276 Remove not needed jmx settings

### DIFF
--- a/ivy-visualvm/jvm.options
+++ b/ivy-visualvm/jvm.options
@@ -8,6 +8,5 @@
 -Dcom.sun.management.jmxremote.ssl=false
 -Dcom.sun.management.jmxremote.autodiscovery=true 
 
--Dcom.sun.management.jmxremote.local.only=false
 -Dcom.sun.management.jmxremote.rmi.port=9003
 -Djava.rmi.server.hostname=127.0.0.1


### PR DESCRIPTION
The settings -Dcom.sun.management.jmxremote.local.only=false is not needed.
See also https://jira.axonivy.com/confluence/display/XIVY/JMX