### PR TITLE
changed keycloak container from jboss to quay.io

### DIFF
--- a/ivy-sso-openid-connect/apache/vhost.conf
+++ b/ivy-sso-openid-connect/apache/vhost.conf
@@ -43,14 +43,14 @@
   OIDCClientID ivy-server-oidc
 
   # url for metadata about the idendity provider
-  OIDCProviderMetadataURL https://keycloak:8443/auth/realms/ivy-demo/.well-known/openid-configuration
-
+  OIDCProviderMetadataURL http://keycloak:8080/realms/ivy-demo/.well-known/openid-configuration
+  
   # in this demos, we need to set an alternative URL for client's access to auth endpoint, because the client must
   # use hostname and port outside the Docker network (usually, this is not needed because it's implcitly set by the
   # metadata downloaded above) while direct access from this server to the idendity provider must use container name and port.
   # for this reason, we will override some setting from the metadata downloaded above.
-  OIDCProviderIssuer https://localhost:8443/auth/realms/ivy-demo
-  OIDCProviderAuthorizationEndpoint https://localhost:8443/auth/realms/ivy-demo/protocol/openid-connect/auth
+  # OIDCProviderIssuer http://localhost:8080/auth/realms/ivy-demo
+  # OIDCProviderAuthorizationEndpoint http://localhost:8080/auth/realms/ivy-demo/protocol/openid-connect/auth
 
   # turn off cert validation, as we deal with self-signed certs only in this demos
   OIDCSSLValidateServer Off 

--- a/ivy-sso-openid-connect/compose.yaml
+++ b/ivy-sso-openid-connect/compose.yaml
@@ -18,12 +18,12 @@ services:
       - ./apache/certs:/certs
 
   keycloak:
-    image: jboss/keycloak
+    image: quay.io/keycloak/keycloak:latest
     environment:
-     - KEYCLOAK_USER=admin
-     - KEYCLOAK_PASSWORD=admin
-     - KEYCLOAK_IMPORT=/shared/realm-ivydemo-import.json
+     - KEYCLOAK_ADMIN=admin
+     - KEYCLOAK_ADMIN_PASSWORD=admin
     volumes:
-     - ./keycloak:/shared
+     - ./keycloak:/opt/keycloak/data/import
     ports:
-     - 8443:8443
+     - 8080:8080
+    command: start-dev --import-realm

--- a/ivy-sso-openid-connect/keycloak/realm-ivydemo-import.json
+++ b/ivy-sso-openid-connect/keycloak/realm-ivydemo-import.json
@@ -1709,7 +1709,8 @@
   "dockerAuthenticationFlow" : "docker auth",
   "attributes" : {
     "clientSessionIdleTimeout" : "0",
-    "clientSessionMaxLifespan" : "0"
+    "clientSessionMaxLifespan" : "0",
+    "frontendUrl": "http://localhost:8080"
   },
   "keycloakVersion" : "10.0.1",
   "userManagedAccessAllowed" : false


### PR DESCRIPTION
- switched to quay.io docker container for ivy-sso-openid-connect demo
- dropped keycloak ssl support (which is no longer included in the container)
- changed front-end URL to localhost in realm export