### PR TITLE
XIVY-14561 expose all DB ports

### DIFF
--- a/ivy-systemdb-mariadb/compose.yaml
+++ b/ivy-systemdb-mariadb/compose.yaml
@@ -2,14 +2,16 @@ services:
   ivy:
     image: axonivy/axonivy-engine:dev
     ports:
-     - 8080:8080
+      - 8080:8080
     volumes:
      - ../demo-licence.lic:/etc/axonivy-engine/demo-licence.lic
      - ./ivy.yaml:/etc/axonivy-engine/ivy.yaml
   mariadb:
     image: mariadb
-    ports:
-      - 3306:3306
+    # if you want to use this as a development database and 
+    # access it with a 3rd party database client like DBeaver, uncomment the following 2 lines.
+    # ports:
+    #   - 3306:3306
     environment:
       MYSQL_ROOT_PASSWORD: 1234
 

--- a/ivy-systemdb-mariadb/compose.yaml
+++ b/ivy-systemdb-mariadb/compose.yaml
@@ -8,6 +8,8 @@ services:
      - ./ivy.yaml:/etc/axonivy-engine/ivy.yaml
   mariadb:
     image: mariadb
+    ports:
+      - 3306:3306
     environment:
       MYSQL_ROOT_PASSWORD: 1234
 

--- a/ivy-systemdb-mariadb/compose.yaml
+++ b/ivy-systemdb-mariadb/compose.yaml
@@ -2,7 +2,7 @@ services:
   ivy:
     image: axonivy/axonivy-engine:dev
     ports:
-      - 8080:8080
+     - 8080:8080
     volumes:
      - ../demo-licence.lic:/etc/axonivy-engine/demo-licence.lic
      - ./ivy.yaml:/etc/axonivy-engine/ivy.yaml
@@ -11,7 +11,7 @@ services:
     # if you want to use this as a development database and 
     # access it with a 3rd party database client like DBeaver, uncomment the following 2 lines.
     # ports:
-    #   - 3306:3306
+    #  - 3306:3306
     environment:
       MYSQL_ROOT_PASSWORD: 1234
 

--- a/ivy-systemdb-mssql/compose.yaml
+++ b/ivy-systemdb-mssql/compose.yaml
@@ -8,8 +8,10 @@ services:
      - ./ivy.yaml:/etc/axonivy-engine/ivy.yaml
   mssql:
     image: mcr.microsoft.com/mssql/server
-    ports: 
-      - 1433:1433
+    # if you want to use this as a development database and 
+    # access it with a 3rd party database client like DBeaver, uncomment the following 2 lines.
+    # ports:
+    # - 1433:1433
     environment:
       ACCEPT_EULA: "Yes"
       SA_PASSWORD: secure1234PASSWORD!

--- a/ivy-systemdb-mssql/compose.yaml
+++ b/ivy-systemdb-mssql/compose.yaml
@@ -8,6 +8,8 @@ services:
      - ./ivy.yaml:/etc/axonivy-engine/ivy.yaml
   mssql:
     image: mcr.microsoft.com/mssql/server
+    ports: 
+      - 1433:1433
     environment:
       ACCEPT_EULA: "Yes"
       SA_PASSWORD: secure1234PASSWORD!

--- a/ivy-systemdb-mysql/compose.yaml
+++ b/ivy-systemdb-mysql/compose.yaml
@@ -9,7 +9,9 @@ services:
 
   mysql:
     image: mysql
-    ports:
-     - 3306:3306
+    # if you want to use this as a development database and 
+    # access it with a 3rd party database client like DBeaver, uncomment the following 2 lines.
+    # ports:
+    #  - 3306:3306
     environment:
       MYSQL_ROOT_PASSWORD: 1234

--- a/ivy-systemdb-postgres/compose.yaml
+++ b/ivy-systemdb-postgres/compose.yaml
@@ -9,6 +9,8 @@ services:
 
   postgres:
     image: postgres
+    ports:
+      - 5432:5432
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: 1234

--- a/ivy-systemdb-postgres/compose.yaml
+++ b/ivy-systemdb-postgres/compose.yaml
@@ -9,8 +9,10 @@ services:
 
   postgres:
     image: postgres
-    ports:
-      - 5432:5432
+    # if you want to use this as a development database and 
+    # access it with a 3rd party database client like DBeaver, uncomment the following 2 lines.
+    # ports:
+    # - 5432:5432
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: 1234


### PR DESCRIPTION
To allow working with a DB Client (like dBeaver CE) on a containerized Axon Ivy System Database, we expose the database ports to the host environment for all system database docker samples.