### PR TITLE
Allow to restart ivy or start ivy after nginx

### DIFF
--- a/ivy-tracing-jaeger/reverseProxy/ngnix.conf
+++ b/ivy-tracing-jaeger/reverseProxy/ngnix.conf
@@ -21,8 +21,8 @@ http {
 
   server {
     server_name localhost;
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
     ssl_certificate /etc/nginx/certs/server.crt;
     ssl_certificate_key /etc/nginx/certs/server.key;
     ssl_protocols TLSv1.2 TLSv1.3;
@@ -54,10 +54,12 @@ http {
       proxy_redirect http:// $scheme://;
       proxy_send_timeout 240;
 
+      opentracing_operation_name "$request_method $uri";
       # Propagates the tracing context to upstream services using the Jaeger specific http header 'uber-trace-id'  
       opentracing_propagate_context;
       
-      proxy_pass http://ivy:8080/;
+      resolver 127.0.0.11 valid=30s;
+      proxy_pass http://ivy:8080$request_uri;
     }
   }
 }


### PR DESCRIPTION
- Report method and url in span name of nginx
- Remove opsolete http2