### PR TITLE
XIVY-18650 refactor: select with tags query

### DIFF
--- a/ivy-tracing/test.sh
+++ b/ivy-tracing/test.sh
@@ -13,18 +13,14 @@ fi
 # find trace
 json=""
 matches=0
-api="${jaeger}/api/traces?limit=2000&lookback=5m&service=Reverse%20Proxy"
-for i in {1..15}; do
+retries=15
+tags_json=$(jq -cn --arg url "$proxy" '{"http.url": $url}')
+tags_encoded=$(printf '%s' "$tags_json" | jq -sRr @uri)
+api="${jaeger}/api/traces?limit=2000&lookback=5m&service=Reverse%20Proxy&tags=${tags_encoded}"
+for i in $(seq 1 $retries); do
   echo "$i: $api"
   json=$(curl -s "${api}")
-  matches=$(echo "$json" | jq -r --arg target "$proxy" '
-    [
-      .data[].spans[]
-      | select((.references | length) == 0)
-      | select(any(.tags[]?; .key == "http.url" and (.value | contains($target))))
-    ]
-    | length
-  ')
+  matches=$(echo "$json" | jq -r --arg target "$proxy" '[ .data[] ] | length')
   if [[ "$matches" -gt 0 ]]; then
     break
   fi
@@ -32,31 +28,16 @@ for i in {1..15}; do
 done
 if [[ "$matches" -eq 0 ]]; then
   echo "Jaeger responded: $json"
-  echo "FAIL: no matching reverse-proxy trace with http.url containing '$proxy' after 5 retries"
+  echo "FAIL: no matching reverse-proxy trace with http.url containing '$proxy' after $retries retries"
   exit 1
 fi
 
-# full span info
 sleep 2 # wait until all processes sent their spans
-json=$(curl -s "${api}")
-matches=$(echo "$json" | jq -r --arg target "$proxy" '
-  [
-    .data[].spans[]
-    | select((.references | length) == 0)
-    | select(any(.tags[]?; .key == "http.url" and (.value | contains($target))))
-    | .traceID
-  ]
-')
-traceId=$(echo $matches | sed -E 's/.*"([a-z0-9]*)".*/\1/')
-echo $traceId
-if [[ -z "$traceId" ]]; then
-  echo "Jaeger responded: $json"
-  echo "FAIL: no matching trace found for '$what'"
-  exit 1
-fi
-trace=$(echo "$json" | jq -r --arg traceId "$traceId" 'first(.data[] | select(.traceID == $traceId and (has("spanID") | not)) )')
+json=$(curl -s "${api}") # re-query to get all spans of the trace
 
 # test involved services
+trace=$(echo "$json" | jq -r 'first(.data[] )')
+echo "$trace" | jq -r '.traceID'
 services=$(echo "$trace" | jq -r '[.processes[].serviceName] | sort | unique | join(",")')
 expected="Axon Ivy Engine,Backend,Reverse Proxy"
 if [[ "$services" != "$expected" ]]; then


### PR DESCRIPTION
found out that there exists a more straight-forward query to select a root trace for a certain URI... so we can simplify the test a lot.
... still java, sorry @weissreto :wink: . But IMHO simpler and expressive.